### PR TITLE
fix: use timezone setting from dateTime

### DIFF
--- a/src/helpers/google.ts
+++ b/src/helpers/google.ts
@@ -21,7 +21,7 @@ export async function getCalendar(url) {
   const timeMax = date.toISOString();
   url = `https://clients6.google.com/calendar/v3/calendars/c_o9gndn4n4hmcsbthvkplgrlegs@group.calendar.google.com/events?calendarId=c_o9gndn4n4hmcsbthvkplgrlegs%40group.calendar.google.com&singleEvents=true&orderBy=startTime&maxResults=50&sanitizeHtml=true&timeMin=${timeMin}&timeMax=${timeMax}&key=AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs`;
 
-  let { items } = await fetch(url).then(res => res.json());
+  const { items } = await fetch(url).then(res => res.json());
 
   return items.map(item => {
     item.start.ts = new Date(item.start.dateTime).getTime() / 1e3;

--- a/src/helpers/google.ts
+++ b/src/helpers/google.ts
@@ -23,28 +23,10 @@ export async function getCalendar(url) {
 
   let { items } = await fetch(url).then(res => res.json());
 
-  items = items.map(item => {
-    item.start.ts = parseInt(
-      (
-        new Date(
-          new Date(item.start.dateTime).toLocaleString('en-US', {
-            timeZone: item.start.timeZone
-          })
-        ).getTime() / 1e3
-      ).toFixed()
-    );
-    item.end.ts = parseInt(
-      (
-        new Date(
-          new Date(item.end.dateTime).toLocaleString('en-US', {
-            timeZone: item.end.timeZone
-          })
-        ).getTime() / 1e3
-      ).toFixed()
-    );
+  return items.map(item => {
+    item.start.ts = new Date(item.start.dateTime).getTime() / 1e3;
+    item.end.ts = new Date(item.end.dateTime).getTime() / 1e3;
 
     return item;
   });
-
-  return items;
 }


### PR DESCRIPTION
`dateTime` already has timezone info and current implementation seems not to work well (on Firefox/Safari it returns incorrect times, on Chrome it gives bunch of NaN/Invalid Date).

## Test plan

Go to http://127.0.0.1:8080/#/gang/sx-core on (Safari/FF/Chrome) times show up and are correct.
